### PR TITLE
fix: remove plugin context, format code

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import {
-  // Logo,
   PluginProvider,
   Stack,
   Title,
@@ -9,22 +8,17 @@ import "../baseStyles.css";
 import ErrorBoundary from "./ErrorBoundary";
 import LineChart from "./LineChart";
 
-import PluginContext from "./PluginContext";
-
 const App: React.FC = () => {
   return (
     <ErrorBoundary>
       <PluginProvider>
         <Stack>
-          {/* <Logo /> */}
           <Title level={1}>Cloud costs in the last 8 weeks</Title>
         </Stack>
         <LineChart />
-        <PluginContext />
       </PluginProvider>
     </ErrorBoundary>
   );
 };
-
 
 export default App;

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -1,30 +1,39 @@
-import React from 'react';
-import { Line } from 'react-chartjs-2';
-import 'chart.js/auto';
-import { ChartData, ChartOptions } from 'chart.js';
+import type React from "react";
+import { Line } from "react-chartjs-2";
+import "chart.js/auto";
+import { type ChartData, type ChartOptions } from "chart.js";
 
 const LineChart: React.FC = () => {
   // Data for the graph
-  const data: ChartData<'line'> = {
-    labels: ['First Week', 'Second Week', 'Third Week', 'Fourth Week', 'Fifth Week', 'Sixth Week', 'Seventh Week', 'Eighth Week'],
+  const data: ChartData<"line"> = {
+    labels: [
+      "First Week",
+      "Second Week",
+      "Third Week",
+      "Fourth Week",
+      "Fifth Week",
+      "Sixth Week",
+      "Seventh Week",
+      "Eighth Week",
+    ],
     datasets: [
       {
-        label: 'Costs Over Time',
+        label: "Costs Over Time",
         data: [2613, 1000, 1650, 3042, 515, 9767, 667, 823],
         fill: false,
-        borderColor: 'rgb(75, 192, 192)',
-        tension: 0.1
-      }
-    ]
+        borderColor: "rgb(75, 192, 192)",
+        tension: 0.1,
+      },
+    ],
   };
 
   // Options for the graph
-  const options: ChartOptions<'line'> = {
+  const options: ChartOptions<"line"> = {
     scales: {
       y: {
-        beginAtZero: true
-      }
-    }
+        beginAtZero: true,
+      },
+    },
   };
 
   return <Line data={data} options={options} />;

--- a/src/components/PluginContext.tsx
+++ b/src/components/PluginContext.tsx
@@ -6,9 +6,9 @@ const PluginContext: React.FC = () => {
 
   return (
     <>
-      <div style={{display:"none"}}>
-      <Title level={2}>Plugin context</Title>
-      <pre>{JSON.stringify(context, null, 2)}</pre>
+      <div style={{ display: "none" }}>
+        <Title level={2}>Plugin context</Title>
+        <pre>{JSON.stringify(context, null, 2)}</pre>
       </div>
     </>
   );

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     ></script>
   </head>
   <body>
-  <div id="cortex-plugin-root"></div>
+    <div id="cortex-plugin-root"></div>
   </body>
   <!-- <div class="iframe">
     <iframe width="100%" height="100%" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vSXKrhWs5fqDPg2u20RIsYAkoCHzGP5HDgxUIOInPNXIes_lpeXUA6r0Z5gcuvpznYhfM_ofLQyLOYh/pubhtml?gid=1562819290&amp;single=true&amp;widget=true&amp;headers=false"></iframe>       


### PR DESCRIPTION
* Removes the display of the plugin context component for a more professional display (we want to use this plugin in our demo environment)
  * Note that I left the component in the repo for potential future debugging convenience -- let me know if you'd prefer that I remove it entirely
* Applies formatting from `yarn fix`

<img width="1193" alt="Screenshot 2024-06-05 at 5 18 59 PM" src="https://github.com/ilya-cortex-org/cloud-cost-chart-plugin/assets/3069614/d4fd076e-efff-41a1-8781-c2a1a7f31e0d">
<img width="1193" alt="Screenshot 2024-06-05 at 5 18 49 PM" src="https://github.com/ilya-cortex-org/cloud-cost-chart-plugin/assets/3069614/17f58847-91b8-41e6-a51c-759d35bf6d61">
